### PR TITLE
Handle errors parsing Prometheus expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,6 @@ version = "0.1.0"
 authors = ["Stile Developers <developers@stileeducation.com>"]
 edition = "2018"
 
-[workspace]
-members = [
-        "ast-explorer"
-]
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
Previously if we failed to parse an expression there would be a log at
error level but the exit code would still be zero - not what we want!
Now the errors are logged and failure is indicated so that once we've
finished processing the other files we can bubble the error up.